### PR TITLE
fix: use iso 8601 format for zulu time in public api

### DIFF
--- a/src/main/java/no/java/sleepingpill/core/session/Session.java
+++ b/src/main/java/no/java/sleepingpill/core/session/Session.java
@@ -4,7 +4,6 @@ import no.java.sleepingpill.core.util.DateUtil;
 import org.jsonbuddy.JsonArray;
 import org.jsonbuddy.JsonFactory;
 import org.jsonbuddy.JsonObject;
-import org.jsonbuddy.JsonString;
 import org.jsonbuddy.pojo.JsonGenerator;
 
 import java.time.*;
@@ -112,9 +111,7 @@ public class Session extends DataObject {
             return;
         }
         LocalDateTime localdate = LocalDateTime.parse(dataField.get().propertyValue());
-        ZonedDateTime zonedDateTime = localdate.atZone(ZoneId.of("Europe/Oslo"));
-        String zuluTime = zonedDateTime.withZoneSameInstant(ZoneId.of("Z")).toString();
-        dataObj.put(fieldName,zuluTime);
+        dataObj.put(fieldName, DateUtil.toZuluTimeString(localdate));
     }
 
 

--- a/src/main/java/no/java/sleepingpill/core/util/DateUtil.java
+++ b/src/main/java/no/java/sleepingpill/core/util/DateUtil.java
@@ -1,6 +1,9 @@
 package no.java.sleepingpill.core.util;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 public class DateUtil {
     private static DateUtil instance = null;
@@ -14,6 +17,11 @@ public class DateUtil {
 
     public String generateLastUpdated() {
         return LocalDateTime.now().toString();
+    }
+
+    public static String toZuluTimeString(LocalDateTime localdate) {
+        ZonedDateTime zonedDateTime = localdate.atZone(ZoneId.of("Europe/Oslo"));
+        return zonedDateTime.withZoneSameInstant(ZoneId.of("Z")).format(DateTimeFormatter.ISO_DATE_TIME);
     }
 
 }

--- a/src/test/java/no/java/sleepingpill/core/util/DateUtilTest.java
+++ b/src/test/java/no/java/sleepingpill/core/util/DateUtilTest.java
@@ -1,0 +1,19 @@
+package no.java.sleepingpill.core.util;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+
+public class DateUtilTest {
+
+  @Test
+  public void shouldCreateValidIso8601DateFormatInZuluTime() throws Exception {
+    LocalDateTime localdate = LocalDateTime.parse("2016-09-08T07:00");
+    String zuluDateTime = DateUtil.toZuluTimeString(localdate);
+    assertThat(zuluDateTime, is("2016-09-08T05:00:00Z"));
+  }
+
+}


### PR DESCRIPTION
The api didn't include the seconds in the date time format. The default
java 8 api expects it and it should be there to meet the iso 8601 spec.